### PR TITLE
Adds CI test to run pipeline job on CloudOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Submit job with cloudos.py 
         env:
           CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
           TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
         run: |
           git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
-          ls /home/runner/work/hic/
           ls /home/runner/work/hic/hic
           
           response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config ${GITHUB_WORKSPACE}/conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
         run: |
           git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
-          response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
+          response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config ${GITHUB_WORKSPACE}/conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         run: |
           git clone https://github.com/lifebit-ai/cloudos-cli
-          response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t 5c6d3e9bd954e800b23f8c62 -w 'lifebit-ai-hic' --config ../hic/conf/test.config --project_name "API jobs" --job_name "cloudos-cli test")
+          response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t 5c6d3e9bd954e800b23f8c62 -w 'lifebit-ai-hic' --config conf/cloudos_test.config --project_name "API jobs" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,9 @@ jobs:
           TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
         run: |
           git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
-          ls /home/runner/work/hic/hic
-          
+          ls /home/runner/work/hic/hic/conf/
+          echo "next"
+          ls ${GITHUB_WORKSPACE}
           response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config ${GITHUB_WORKSPACE}/conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,39 @@ jobs:
       - name: Run pipeline with test data
         run: |
           nextflow run ${GITHUB_WORKSPACE} --config conf/test.config
+
+  test_cloudos:
+    name: Run workflow tests on CloudOS
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Test with pytest
+        env:
+          CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
+        run: |
+          git clone https://github.com/lifebit-ai/cloudos-cli
+          response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t 5c6d3e9bd954e800b23f8c62 -w 'lifebit-ai-hic' --config ../hic/conf/test.config --project_name "API jobs" --job_name "cloudos-cli test")
+          echo $response
+          id=$(echo $response | cut -f6 -d / -)
+
+          JOB_STATUS='initializing'
+          while [ $JOB_STATUS = "initializing" ] || [ $JOB_STATUS = "running" ]; do
+            sleep 5
+            JOB_STATUS=$(./cloudos-cli/get_job_status.py -a $CLOUDOS_TOKEN -j $id)
+          done
+          
+          if [ $JOB_STATUS = "completed" ]; then
+            echo "Job successfully completed on CloudOS."
+          else
+            echo "Job status: $JOB_STATUS"
+            echo "Error: job $id failed on CLoudOS. Check the job at https://cloudos.lifebit.ai/app/jobs/${id}"
+            exit 123
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,6 @@ jobs:
           TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
         run: |
           git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
-          ls /home/runner/work/hic/hic/conf/
-          echo "next"
-          ls ${GITHUB_WORKSPACE}
           response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config ${GITHUB_WORKSPACE}/conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)
@@ -86,9 +83,9 @@ jobs:
           done
           
           if [ $JOB_STATUS = "completed" ]; then
-            echo "Job successfully completed on CloudOS."
+            echo "SUCCESS! Job successfully completed on CloudOS!"
           else
             echo "Job status: $JOB_STATUS"
-            echo "Error: job $id failed on CLoudOS. Check the job at https://cloudos.lifebit.ai/app/jobs/${id}"
+            echo "ERROR: job $id failed on CLoudOS. Check the job at https://cloudos.lifebit.ai/app/jobs/${id}"
             exit 123
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           CLOUDOS_WORKSPACE: ${{ secrets.CLOUDOS_WORKSPACE }}
           TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
         run: |
-          git clone git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
+          git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
           response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
       - name: Test with pytest
         env:
           CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
+          CLOUDOS_WORKSPACE: ${{ secrets.CLOUDOS_WORKSPACE }}          
         run: |
           git clone https://github.com/lifebit-ai/cloudos-cli
-          response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t 5c6d3e9bd954e800b23f8c62 -w 'lifebit-ai-hic' --config conf/cloudos_test.config --project_name "API jobs" --job_name "cloudos-cli test")
+          response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Test with pytest
+      - name: Submit job with cloudos.py 
         env:
           CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
-          CLOUDOS_WORKSPACE: ${{ secrets.CLOUDOS_WORKSPACE }}          
+          CLOUDOS_WORKSPACE: ${{ secrets.CLOUDOS_WORKSPACE }}
+          TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
         run: |
-          git clone https://github.com/lifebit-ai/cloudos-cli
+          git clone git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
           response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
         run: |
           git clone https://${TOKEN_GITHUB}:x-oauth-basic@github.com/lifebit-ai/cloudos-cli.git
+          ls /home/runner/work/hic/
+          ls /home/runner/work/hic/hic
+          
           response=$(./cloudos-cli/cloudos.py -a $CLOUDOS_TOKEN -t $CLOUDOS_WORKSPACE -w 'lifebit-ai-hic' --config ${GITHUB_WORKSPACE}/conf/cloudos_test.config --project_name "CI tests" --job_name "cloudos-cli test")
           echo $response
           id=$(echo $response | cut -f6 -d / -)

--- a/conf/cloudos_test.config
+++ b/conf/cloudos_test.config
@@ -1,0 +1,3 @@
+params {
+  config = conf/test.config
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,6 +5,8 @@
  * Default config options for all environments.
  */
 
+process.errorStrategy = { task.attempt <= 5 ? 'retry' : 'finish' }
+
 // Global default params, used in configs
 params {
   // Inputs / outputs


### PR DESCRIPTION
## Description
This PR adds a specific CI test that will run current nextflow pipeline with test parameters on Main CloudOS platform (https://cloudos.lifebit.ai/). This is achieved by using [cloudous-cli](https://github.com/lifebit-ai/cloudos-cli) - python-based api client for CloudOS. One commands submits a job to cloudos, and second command is checking the status of job until it is completed or failed.

In result the added step allows to control that developed pipeline not only works locally and with github actions on github test instances, but also works on cloudos with its version of Nextflow.

## Examples of successful CI tests and jobs:
CI test here on github: https://github.com/lifebit-ai/hic/runs/3026221531
Corresponding CloudOS job: https://cloudos.lifebit.ai/app/jobs/60e7e8502f1720019afc6cff

## Images
![image](https://user-images.githubusercontent.com/64809705/125036481-b8ce1b80-e09b-11eb-9d19-9a12dce6a417.png)
![image](https://user-images.githubusercontent.com/64809705/125036491-be2b6600-e09b-11eb-85bf-dc82ad304ec8.png)
