### PR TITLE
Updates test profile to not have array, moves to s3

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -17,12 +17,10 @@ params {
   max_time = 1.h
 
   // Input data
-  input_paths = [
-    ['SRR4292758_00', ['https://github.com/nf-core/test-datasets/raw/hic/data/SRR4292758_00_R1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/hic/data/SRR4292758_00_R2.fastq.gz']]
-   ]
+  input = 's3://lifebit-featured-datasets/pipelines/hic/*_R{1,2}.fastq.gz'
 
   // Annotations
-  fasta = 'https://github.com/nf-core/test-datasets/raw/hic/reference/W303_SGD_2015_JRIU00000000.fsa'
+  fasta = 's3://lifebit-featured-datasets/pipelines/hic/W303_SGD_2015_JRIU00000000.fsa'
   digestion = 'hindiii'
   min_mapq = 10
   min_restriction_fragment_size = 100


### PR DESCRIPTION
## Description

Small PR to update test config so that it doesn't have an array, which is not possible to specify from command line. This way it will be equivalent to test command that we will add to CloudOS "Example data and parameters".